### PR TITLE
feat: avoid double tweeting

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -13,6 +13,7 @@ filters:
   minimum_forecasts: 10 # Minimum number of forecasts made
   types: # Types of questions handled by the bot
     - binary
+  no_duplicate_period: 24 # Number of hours during which a question will be ignored after an alert
 
 # Change thresholds (when at least 1 of these is true, a tweet will be sent)
 # - absolute change of >5% in the last 5 hours

--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ def get_config():
 
 
 def get_recent_alerts(api, no_duplicate_period):
-    tweets = api.user_timeline(screen_name="metaculusalert")
+    tweets = api.user_timeline(screen_name="MetaculusAlert")
     threshold = datetime.datetime.utcnow() - datetime.timedelta(
         hours=no_duplicate_period
     )
@@ -32,7 +32,7 @@ def post_tweet(event="", context=""):
     api = create_api()
     print("API created")
 
-    recent_alerts = get_recent_alerts(config["filters"]["no_duplicate_period"])
+    recent_alerts = get_recent_alerts(api, config["filters"]["no_duplicate_period"])
     print("Fetched recent alerts")
 
     p = predictions(config, recent_alerts)

--- a/main.py
+++ b/main.py
@@ -1,12 +1,41 @@
+import datetime
+import re
 import time
+import yaml
 
 from create_api import create_api
 from get_predictions import predictions
 
+
+def get_config():
+    with open("config.yml") as file:
+        config = yaml.load(file, Loader=yaml.FullLoader)
+    return config
+
+
+def get_recent_alerts(api, no_duplicate_period):
+    tweets = api.user_timeline(screen_name="metaculusalert")
+    threshold = datetime.datetime.utcnow() - datetime.timedelta(
+        hours=no_duplicate_period
+    )
+    titles = []
+    for tweet in tweets:
+        if tweet.created_at.replace(tzinfo=None) < threshold:
+            break
+        titles.append(re.search(r"^([^\n]+)", tweet.text).group(0))
+    return titles
+
+
 def post_tweet(event="", context=""):
+    config = get_config()
+
     api = create_api()
     print("API created")
-    p = predictions()
+
+    recent_alerts = get_recent_alerts(config["filters"]["no_duplicate_period"])
+    print("Fetched recent alerts")
+
+    p = predictions(config, recent_alerts)
     tweets = p.get()
 
     print("---")
@@ -14,7 +43,9 @@ def post_tweet(event="", context=""):
     for tweet in tweets:
         try:
             if tweet:
-                api.update_status_with_media(status=tweet["text"], filename = tweet["chart"])
+                api.update_status_with_media(
+                    status=tweet["text"], filename=tweet["chart"]
+                )
                 print("")
                 print(tweet)
                 time.sleep(10)


### PR DESCRIPTION
- `config.yml`: adds `no_duplicate_period`, which determines for how many hours a question will be ignored after it has already raised an alert. Currently set to `24`
- `main.py`:
  - Parses the config file when execution starts
  - Fetches the user timeline of `MetaculusAlert` from Twitter, and stores the question titles (first line of the tweet) of all tweets sent within the `no_duplicate_period`
  - Passes on these question titles to `predictions()`
- `get_predictions.py`: ignores questions that have recently raised an alert

Fixes #2