### PR TITLE
Adding ability to tweet new questions

### DIFF
--- a/get_predictions.py
+++ b/get_predictions.py
@@ -120,7 +120,7 @@ class predictions:
             alert_text = f"\n{arrow} {change_formatted} in the last {elapsed} hours\n"
         
         if alert_type == "New":
-            alert_text = f"\nNew question\n"
+            alert_text = f"\n🆕 New question\n"
 
         current_pred_formatted = str(round(current_prediction * 100)) + "%"
 


### PR DESCRIPTION
I removed the check within p.is_question_included that checks to see if the question was created within the last 48 hours and added that within p.get. I also changed p.add_tweet so now it has an alert_type parameter with slightly different logic depending on whether alert_type = "New" or "Swing"

Notes:
I haven't tested with the Twitter API
Maybe new question tweet alerts shouldn't include the graph, possibly should be a different template for that type of tweet
I left in the check about having a minimum number of forecasts -- even new questions must satisfy that