### PR TITLE
Add questions from monkeypox project

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -25,7 +25,5 @@ filters:
 # - absolute change of >5% in the last 5 hours
 # - absolute change of >10% in the last 24 hours
 thresholds:
-  - hours: 5
-    swing: 0.05
   - hours: 24
     swing: 0.1

--- a/config.yml
+++ b/config.yml
@@ -29,4 +29,4 @@ thresholds:
   - hours: 24
     swing: 0.1
   - hours: 48
-    swing: 0.1
+    swing: 0.2

--- a/config.yml
+++ b/config.yml
@@ -2,6 +2,7 @@
 # All questions in these projects will be included
 projects:
   - 1426
+  - 1683
 # All questions below will be included
 questions:
   - 2534

--- a/config.yml
+++ b/config.yml
@@ -27,3 +27,5 @@ filters:
 thresholds:
   - hours: 24
     swing: 0.1
+  - hours: 48
+    swing: 0.1


### PR DESCRIPTION
As previously discussed with @nikosbosse, this PR:

- Removes the 5-hour alerts
- Adds an alert for changes ≥10% over 48 hours

It also adds the [monkeypox outbreak project](https://www.metaculus.com/project/monkeypox/) to the list of monitored questions.

If merged then https://twitter.com/MetaculusAlert will probably need a fresh bio :)

Closes #18