### PR TITLE
Add questions from biosecurity tournament

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -3,6 +3,7 @@
 projects:
   - 1426
   - 1683
+  - 1703
 # All questions below will be included
 questions:
   - 2534


### PR DESCRIPTION
The new [Biosecurity Tournament](https://www.metaculus.com/tournament/biosecurity-tournament/) seems like another good one to add to the list of monitored questions.