### PR TITLE
refactor: check for recent alerts based on CSV file

### DIFF
--- a/alerts.csv
+++ b/alerts.csv
@@ -1,0 +1,2 @@
+question_id,last_alert_timestamp
+11939,2022-08-29 06:00:00.000000

--- a/alerts.csv
+++ b/alerts.csv
@@ -1,2 +1,0 @@
-question_id,last_alert_timestamp
-11939,2022-08-29 06:00:00.000000

--- a/get_predictions.py
+++ b/get_predictions.py
@@ -1,7 +1,5 @@
-from calendar import c
 import datetime
 import re
-from unittest import skip
 import requests
 import tempfile
 

--- a/main.py
+++ b/main.py
@@ -27,11 +27,8 @@ def get_recent_alerts(no_duplicate_period):
 def write_recent_alerts(tweets):
     old_alerts = pd.read_csv("alerts.csv")
     new_alerts = pd.DataFrame(
-        {
-            "question_id": [t["question_id"] for t in tweets],
-            "last_alert_timestamp": [str(datetime.datetime.utcnow())],
-        }
-    )
+        {"question_id": [t["question_id"] for t in tweets]}
+    ).assign(last_alert_timestamp=str(datetime.datetime.utcnow()))
     alerts = (
         pd.concat([old_alerts, new_alerts]).groupby("question_id", as_index=False).max()
     )
@@ -53,18 +50,19 @@ def post_tweet(event="", context=""):
 
     print("---")
     print(f"{len(tweets)} tweets queued…")
-    for tweet in tweets:
-        try:
-            if tweet:
-                api.update_status_with_media(
-                    status=tweet["text"], filename=tweet["chart"]
-                )
-                print("")
-                print(tweet)
-                time.sleep(10)
-        except Exception as e:
-            raise e
-    write_recent_alerts(tweets)
+    if len(tweets) > 0:
+        for tweet in tweets:
+            try:
+                if tweet:
+                    api.update_status_with_media(
+                        status=tweet["text"], filename=tweet["chart"]
+                    )
+                    print("")
+                    print(tweet)
+                    time.sleep(10)
+            except Exception as e:
+                raise e
+        write_recent_alerts(tweets)
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -1,5 +1,4 @@
 import datetime
-import re
 import time
 import yaml
 

--- a/main.py
+++ b/main.py
@@ -8,6 +8,8 @@ import pandas as pd
 from create_api import create_api
 from get_predictions import predictions
 
+ALERTS_FILE_GCS = "gs://metaculus-twitter-bot/alerts.csv"
+
 
 def get_config():
     with open("config.yml") as file:
@@ -16,7 +18,7 @@ def get_config():
 
 
 def get_recent_alerts(no_duplicate_period):
-    alerts = pd.read_csv("alerts.csv")
+    alerts = pd.read_csv(ALERTS_FILE_GCS)
     threshold = datetime.datetime.utcnow() - datetime.timedelta(
         hours=no_duplicate_period
     )
@@ -25,14 +27,14 @@ def get_recent_alerts(no_duplicate_period):
 
 
 def write_recent_alerts(tweets):
-    old_alerts = pd.read_csv("alerts.csv")
+    old_alerts = pd.read_csv(ALERTS_FILE_GCS)
     new_alerts = pd.DataFrame(
         {"question_id": [t["question_id"] for t in tweets]}
     ).assign(last_alert_timestamp=str(datetime.datetime.utcnow()))
     alerts = (
         pd.concat([old_alerts, new_alerts]).groupby("question_id", as_index=False).max()
     )
-    alerts.to_csv("alerts.csv", index=False)
+    alerts.to_csv(ALERTS_FILE_GCS, index=False)
     return True
 
 

--- a/main.py
+++ b/main.py
@@ -24,15 +24,17 @@ def get_recent_alerts(no_duplicate_period):
     return recently_tweeted.question_id.values
 
 
-def write_recent_alert(question_id):
-    alerts = pd.read_csv("alerts.csv")
-    new_alert = pd.DataFrame(
+def write_recent_alerts(tweets):
+    old_alerts = pd.read_csv("alerts.csv")
+    new_alerts = pd.DataFrame(
         {
-            "question_id": [question_id],
+            "question_id": [t["question_id"] for t in tweets],
             "last_alert_timestamp": [str(datetime.datetime.utcnow())],
         }
     )
-    alerts = pd.concat([alerts, new_alert]).groupby("question_id", as_index=False).max()
+    alerts = (
+        pd.concat([old_alerts, new_alerts]).groupby("question_id", as_index=False).max()
+    )
     alerts.to_csv("alerts.csv", index=False)
     return True
 
@@ -59,10 +61,10 @@ def post_tweet(event="", context=""):
                 )
                 print("")
                 print(tweet)
-                write_recent_alert(tweet["question_id"])
                 time.sleep(10)
         except Exception as e:
             raise e
+    write_recent_alerts(tweets)
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ certifi==2021.10.8
 charset-normalizer==2.0.12
 cycler==0.11.0
 fonttools==4.29.1
+gcsfs==2022.8.2
 idna==3.3
 kiwisolver==1.3.2
 matplotlib==3.5.1


### PR DESCRIPTION
This PR refactors our system for checking recent alerts and avoiding double posting.

Instead of listing recent alerts by fetching recent tweets and parsing the question title (which was prone to errors), we now have a small CSV file (`alerts.csv`) that lists `question_id` and `last_alert_timestamp`.

Closes #24 