### PR TITLE
fix: remove future data points & exclude question 10557

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -33,6 +33,8 @@ filters:
     - binary
     - continuous
   no_duplicate_period: 24 # Number of hours during which a question will be ignored after an alert
+  excluded_questions:
+    - 10557
 
 # Change thresholds (when at least 1 of these is true, a tweet will be sent)
 # - absolute change of >5% in the last 5 hours

--- a/get_predictions.py
+++ b/get_predictions.py
@@ -212,6 +212,7 @@ class predictions:
 
                 # convert timestamps to datetime
                 df["time"] = pd.to_datetime(df.time, unit="s")
+                df = df.sort_values("time")
 
                 # remove data points in the future
                 df = df[df.time <= datetime.datetime.now()]

--- a/get_predictions.py
+++ b/get_predictions.py
@@ -208,6 +208,9 @@ class predictions:
                 # convert timestamps to datetime
                 df["time"] = pd.to_datetime(df.time, unit="s")
 
+                # remove data points in the future
+                df = df[df.time <= datetime.datetime.now()]
+
                 if prediction_type == "continuous":
                     lower_bound = data["possibilities"]["scale"]["min"]
                     upper_bound = data["possibilities"]["scale"]["max"]

--- a/get_predictions.py
+++ b/get_predictions.py
@@ -175,6 +175,11 @@ class predictions:
 
         question_ids = self.get_question_ids()
 
+        # remove excluded questions
+        question_ids = [
+            qid for qid in question_ids if qid not in self.filters["excluded_questions"]
+        ]
+
         # for every question, get past community predictions and compare whether there has been a significant change
         for id in question_ids:
             question_url = "https://www.metaculus.com/api2/questions/" + str(id)


### PR DESCRIPTION
This PR fixes https://github.com/nikosbosse/Metaculus-Twitter-bot/issues/28.

## Bad formatting

This will fix the bad formatting in the last few tweets of question 10557:

<img width="579" alt="image" src="https://user-images.githubusercontent.com/7103774/209542271-dc94881a-6f8e-42bc-bd1b-b45cbf3a2b4a.png">

This is due to question 10557 having – for some reason – data points in the future:

```
time                            lower  middle  upper
2022-11-04 22:44:54.744327168   0.10   0.20    0.25
2022-11-06 21:23:29.295725312   0.10   0.20    0.29
2022-11-08 23:28:00.000000000   0.10   0.20    0.29
2023-12-30 17:00:00.000000000   0.10   0.20    0.29
2022-12-26 09:27:23.602747648   0.26   0.35    0.50
2023-12-30 17:00:00.000000000   0.10   0.20    0.29
```

## Possible issue with question 10557

On top of this, there seems to be an issue with question 10557 specifically. As shown above, in the time series the recent swing in the forecast seems to always be attributed to the current day (2022-12-26, currently); when we know [from the bot](https://twitter.com/MetaculusAlert/status/1604718578200199173) that this swing appeared first on 19 Dec. Because of this, everyday the bot sees a new swing and tweets an alert.

Combined with the first issue of data points in the future, my best guess is that there is an issue with question 105557 on Metaculus's end.

For now, I've added an `excluded_questions` section in the `filters`, and I've excluded Q10557 from the bot's list.